### PR TITLE
Fix typo preventing ClamAV working

### DIFF
--- a/install/security/clamav.sh
+++ b/install/security/clamav.sh
@@ -14,7 +14,7 @@ if ! command -v clamd &> /dev/null; then
   echo "fs.inotify.max_user_watches = 524288" | sudo tee -a "/etc/sysctl.conf"
 
   echo "OnAccessExcludeUname clamav" | sudo tee -a "/etc/clamav/clamd.conf"
-  echo "OnAccessExlucdeRootUID true" | sudo tee -a "/etc/clamav/clamd.conf"
+  echo "OnAccessExcludeRootUID true" | sudo tee -a "/etc/clamav/clamd.conf"
   echo "OnAccessIncludePath /home" | sudo tee -a "/etc/clamav/clamd.conf"
 
   sudo systemctl enable clamonacc


### PR DESCRIPTION
After starting the on-access scanner I was seeing an error in my syslog about the configuration. After some head-scratching I discovered this typo. I fixed it and now ClamAV on-access scanning works. Thank you!

I verified ClamAV works with:

```console
~/Desktop/test 
❯ echo 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*' > clamav-testfile

~/Desktop/test 
❯ ll
total 8
drwxrwxr-x 2 henare henare 4096 Aug  6 10:52 ./
drwxr-xr-x 3 henare henare 4096 Aug  6 10:51 ../

~/Desktop/test 
❯ ll /quarantine/
total 12
drwxr-xr-x  2 root   root   4096 Aug  6 10:52 ./
drwxr-xr-x 23 root   root   4096 Aug  6 10:35 ../
-rw-rw-r--  1 henare henare   69 Aug  6 10:52 clamav-testfile

~/Desktop/test 
❯ 
```